### PR TITLE
Better S&R filename sanitizer

### DIFF
--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -81,7 +81,7 @@ export function applyTextReplacements(app: ComfyApp, value: string): string {
       return match
     }
 
-    return ((widget.value ?? '') + '').replaceAll(/\/|\\/g, '_')
+    return ((widget.value ?? '') + '').replaceAll(/[\/\?<>\\:\*\|"\x00-\x1F\x7F]/g, '_')
   })
 }
 


### PR DESCRIPTION
Currently an injected colon into a SaveImage node causes the filename on the server to be truncated (on Windows).

![image](https://github.com/user-attachments/assets/12c7afd5-6792-4d4e-8ca5-04a6f7fc1dda)



